### PR TITLE
加速のSEが鳴らなくなる不具合を修正

### DIFF
--- a/10Jam/Chara/AccelSpot.cpp
+++ b/10Jam/Chara/AccelSpot.cpp
@@ -24,7 +24,7 @@ void AccelSpot::Update() {
 
 	if (isCollision && !player_->GetBoost()) {
 		player_->SetBoost(true);
-		Sound::Ins()->Play(accelSe, false, DX_PLAYTYPE_BACK);
+		Sound::Ins()->Play(accelSe, true, DX_PLAYTYPE_BACK);
 	}
 
 	{


### PR DESCRIPTION
加速SE再生時の`topPositionFlag`を`false`→`true`にした